### PR TITLE
fix: corrige caminho do Artifact Registry no deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,15 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - main          # dispara quando há commit na main
-  workflow_dispatch:  # botão “Run workflow” na UI
+    branches: [main]        # dispara ao fazer push na main
+  workflow_dispatch:        # botão “Run workflow”
 
 concurrency:
-  group: deploy-main  # garante 1 deploy por vez
+  group: deploy-main        # só 1 deploy ativo
   cancel-in-progress: true
 
 env:
-  GCP_REGION: us-east4   # ajuste se usar outra região
+  GCP_REGION: us-east4      # se mudar a região, altere aqui
 
 jobs:
   deploy:
@@ -22,14 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 2 – autentica na GCP (service‑account salva em secret)
+      # 2 – login na GCP com a service-account (JSON no secret)
       - name: Auth
         id: auth
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      # 3 – instala gcloud e define o projeto
+      # 3 – instala gcloud + config do projeto
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
         with:
@@ -40,25 +39,25 @@ jobs:
         run: |
           gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
-      # 5 – build da imagem e exporta IMAGE_URI
+      # 5 – build da imagem e grava IMAGE_URI no GITHUB_ENV
       - name: Build image
         run: |
           IMAGE_URI="${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/jarvis-repo/jarvis-bot:${{ github.sha }}"
           docker build -t "$IMAGE_URI" .
           echo "IMAGE_URI=$IMAGE_URI" >> "$GITHUB_ENV"
 
-      # 6 – push da imagem com SHA
+      # 6 – push da imagem com tag SHA
       - name: Push image (sha)
         run: docker push "$IMAGE_URI"
 
-      # 7 – (opcional) tag latest
+      # 7 – **opcional**: também empurra tag latest
       - name: Tag & push latest
         run: |
           LATEST="${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/jarvis-repo/jarvis-bot:latest"
           docker tag "$IMAGE_URI" "$LATEST"
           docker push "$LATEST"
 
-      # 8 – deploy no Cloud Run
+      # 8 – deploy (ou update) no Cloud Run
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy jarvis-bot-run \
@@ -68,7 +67,7 @@ jobs:
             --port=8080 \
             --allow-unauthenticated
 
-      # 9 – captura a URL pública do serviço
+      # 9 – obtém a URL pública gerada
       - name: Get service URL
         id: url
         run: |
@@ -78,9 +77,9 @@ jobs:
           echo "SERVICE_URL=$URL" >> "$GITHUB_ENV"
           echo "Service URL: $URL"
 
-      # 10 – smoke‑test simples na raiz (/) com retries
+      # 10 – smoke test simples na raiz (/) com retries
       - name: Smoke test
         run: |
-          echo "Waiting 60 s for TLS certificate propagation..."
+          echo "Aguardando 60 s para propagação do certificado TLS..."
           sleep 60
           curl -f --retry 5 --retry-delay 10 "$SERVICE_URL"


### PR DESCRIPTION
### Contexto
* Ajusta o prefixo do Artifact Registry para **us-east4-docker.pkg.dev/jarvis-bot-prod/jarvis-repo**  
* Permite que a etapa **Push image** faça upload sem erro de permissão ou repositório inexistente.

### Testes
* Workflow **Deploy** executado localmente com `act` → passou até o passo _Push image_.
* Commit deste PR deve disparar o deploy automático e publicar a imagem corretamente.
