### PR TITLE
feat(schedule): add /schedule/run executor (CRON_KEY) + fila idempotente; deprecate legacy in-memory cron

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,11 +1,13 @@
 // server.js
+'use strict';
 require('dotenv').config();
 
 const express = require('express');
 const helmet  = require('helmet');
 const morgan  = require('morgan');
-// const cors = require('cors');           // descomente se precisar liberar CORS
+// const cors = require('cors'); // descomente se precisar liberar CORS
 
+const log = require('./src/utils/log');
 const scheduleRouter = require('./src/routes/schedule');
 const postsRouter    = require('./src/routes/posts');
 const webhookRouter  = require('./src/routes/webhook');
@@ -14,41 +16,66 @@ const adsRouter      = require('./src/routes/ads');
 
 const app = express();
 
+// Cloud Run/Proxy: respeita X-Forwarded-* (IP, proto, host)
+app.set('trust proxy', true);
+app.disable('x-powered-by');
+
 /* ───── Middlewares básicos ───── */
-app.use(helmet());
-app.use(morgan('tiny'));
-app.use(express.json());
+app.use(helmet({
+  crossOriginResourcePolicy: { policy: 'cross-origin' }, // evita bloqueio de assets externos
+}));
+
+// logger http → nosso logger
+const httpLog = log.child({ module: 'http' });
+app.use(morgan('tiny', { stream: { write: msg => httpLog.info(msg.trim()) } }));
+
+/* ───── Webhook ANTES do body-parser global ─────
+   (o router do webhook usa um json parser próprio que preserva req.rawBody
+    para validar X-Hub-Signature-256 do Meta) */
+app.use('/webhooks', webhookRouter);
+
+// Body-parser global para o resto das rotas
+app.use(express.json({ limit: '1mb' }));
 app.use(express.urlencoded({ extended: true }));
-// app.use(cors());
+// app.use(cors()); // habilite se precisar liberar CORS
 
 /* ───── Rotas principais ───── */
-app.use('/schedule',  scheduleRouter);  // (POST /schedule - criação de job)
-app.use('/posts',     postsRouter);     // (GET /posts/ping | POST /posts/create)
-app.use('/webhooks',  webhookRouter);   // (POST /webhooks/instagram …)
+app.use('/schedule',  scheduleRouter);   // POST /schedule
+app.use('/posts',     postsRouter);      // GET /posts/ping | POST /posts/create
 app.use('/instagram', instaRouter);
 app.use('/ads',       adsRouter);
 
-/* ───── Health-check & raiz ───── */
-app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+/* ───── Health-checks ───── */
+app.get('/health',  (_req, res) => res.json({ status: 'ok' })); // liveness
+app.get('/healthz', (_req, res) => res.status(200).send('ok')); // readiness simples
 app.get('/',        (_req, res) => res.send('jarvis-bot API online'));
 
 /* ───── 404 genérico ───── */
 app.use((req, res) => {
+  log.warn('404 %s %s', req.method, req.originalUrl);
   res.status(404).json({ error: 'Not found', path: req.originalUrl });
 });
 
 /* ───── Middleware de erro ───── */
-app.use((err, _req, res, _next) => {
-  console.error(err);
+app.use((err, req, res, _next) => {
+  log.error('Unhandled error on %s %s', req.method, req.originalUrl, err);
   res.status(500).json({ error: 'Internal server error' });
 });
 
+/* ───── Airbags do processo ───── */
+process.on('unhandledRejection', (reason, p) => {
+  log.error('unhandledRejection at %s', p, reason);
+});
+process.on('uncaughtException', (err) => {
+  log.error('uncaughtException', err);
+});
+
 /* ───── Inicialização ───── */
-const PORT = process.env.PORT || 8080;
+const PORT = Number(process.env.PORT) || 8080;
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, '0.0.0.0', () =>
-    console.log(`jarvis-bot API listening on port ${PORT}`),
-  );
+  app.listen(PORT, '0.0.0.0', () => {
+    log.info('jarvis-bot listening on port %d (env=%s)', PORT, process.env.NODE_ENV || 'development');
+  });
 }
 
 module.exports = app;

--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -2,46 +2,57 @@
 'use strict';
 
 const express = require('express');
+const router  = express.Router();
+
+const log = require('../utils/log');
 const { createImagePost, publishPost } = require('../services/instagram');
 
-const router = express.Router();
-
-// helper: cache‑buster pra mesma URL não ficar “presa” no IG
-function bust(url) {
-  const u = String(url || '').trim();
-  if (!u) return u;
-  if (/\bts=\d+/.test(u)) return u; // já tem ts
-  return u.includes('?') ? `${u}&ts=${Date.now()}` : `${u}?ts=${Date.now()}`;
+// cache-buster pra mesma URL não “prender” no IG
+function bust(u) {
+  const url = String(u || '').trim();
+  if (!url) return url;
+  if (/\bts=\d+/.test(url)) return url;
+  return url.includes('?') ? `${url}&ts=${Date.now()}` : `${url}?ts=${Date.now()}`;
 }
 
-// health check
+// health
 router.get('/ping', (_req, res) => {
-  res.json({ status: 'posts ok' });
+  log.info('GET /posts/ping');
+  res.json({ ok: true, now: new Date().toISOString() });
 });
 
-// cria + publica uma imagem
+// cria + publica imagem
 router.post('/create', async (req, res) => {
   const body = req.body || {};
-  const caption = typeof body.caption === 'string' ? body.caption : '';
+  const caption   = typeof body.caption   === 'string' ? body.caption   : '';
   const image_url = typeof body.image_url === 'string' ? body.image_url : '';
 
+  log.info('POST /posts/create');
+  log.debug('payload: caption="%s" image_url=%s', caption, image_url);
+
   if (!image_url) {
-    return res.status(400).json({ ok: false, error: 'image_url é obrigatório' });
+    log.warn('missing image_url');
+    return res.status(400).json({ ok: false, error: 'missing_image_url' });
   }
 
   try {
-    // 1) cria o container (ORDEM CERTA: image_url, caption) + bust pra evitar cache
+    // 1) cria container
     const creationId = await createImagePost(bust(image_url), caption);
+    log.info('container=%s', creationId);
 
-    // 2) publica (publishPost já retorna apenas o ID)
+    // 2) publica (espera FINISHED por dentro)
     const mediaId = await publishPost(creationId);
+    log.info('published=%s', mediaId);
 
     return res.json({ ok: true, media_id: mediaId, creation_id: creationId });
   } catch (err) {
-    // erro detalhado pra diagnosticar rápido no Postman/Cloud Run logs
-    const details = err?.response?.data || err?.details || { message: err.message };
-    console.error('IG publish error:', details);
-    return res.status(500).json({ ok: false, error: 'Erro ao publicar', details });
+    log.error('create post failed', err);
+    const status = err?.response?.status;
+    return res.status(status && status >= 400 && status < 600 ? status : 500).json({
+      ok: false,
+      error: 'publish_failed',
+      details: err?.response?.data || err?.details || { message: err.message },
+    });
   }
 });
 

--- a/src/routes/schedule.js
+++ b/src/routes/schedule.js
@@ -1,68 +1,130 @@
 // src/routes/schedule.js
 const express = require('express');
 const cron    = require('node-cron');
-const ig      = require('../services/instagram');   // precisa exportar createImagePost / publishPost
+const crypto  = require('crypto');
+const ig      = require('../services/instagram');
+const log     = require('../utils/log');
 
 const router = express.Router();
-const queue  = [];               // memória simples
 
-/* -------------------------------------------------------------------- */
-/*  API DE AGENDAMENTO DE POSTS                                         */
-/* -------------------------------------------------------------------- */
+// Fila simples em memória (MVP). Em produção: Firestore/Postgres.
+const queue = [];
+let running = false;
 
-/**
- * GET /schedule/ping  – health-check
- */
+/* ------------------------------- Health ------------------------------- */
 router.get('/ping', (_req, res) => {
   res.json({ status: 'schedule ok' });
 });
 
+/* ----------------------------- Enfileirar ----------------------------- */
 /**
  * POST /schedule
- *
  * Body:
  * {
- *   "imageUrl": "...jpg",
+ *   "imageUrl": "...jpg",            // aceita também "image_url"
  *   "caption" : "Test ✍️",
- *   "publishAt": "2025-07-24T23:06:00Z"   // ISO-8601 UTC
+ *   "publishAt": "2025-07-24T23:06:00Z"   // ISO-8601 (aceita "publish_at")
  * }
  */
 router.post('/', (req, res) => {
-  const { imageUrl, caption, publishAt } = req.body;
+  const imageUrl = req.body.imageUrl ?? req.body.image_url;
+  const caption  = req.body.caption;
+  const publishAt = req.body.publishAt ?? req.body.publish_at;
 
   if (!imageUrl || !caption || !publishAt) {
     return res.status(400).json({
       ok   : false,
-      error: 'Campos obrigatórios: imageUrl, caption, publishAt',
+      error: 'Campos obrigatórios: imageUrl (ou image_url), caption, publishAt (ou publish_at) em ISO',
+      traceId: req.id
     });
   }
 
-  queue.push({ imageUrl, caption, publishAt, done: false });
-  return res.status(201).json({ ok: true, queued: true });
+  const ts = Date.parse(publishAt);
+  if (Number.isNaN(ts)) {
+    return res.status(400).json({ ok: false, error: 'publishAt inválido (use ISO-8601, ex.: 2025-07-24T23:06:00Z)', traceId: req.id });
+  }
+
+  const idempotencyKey = crypto
+    .createHash('sha256')
+    .update(`${imageUrl}\n${caption}\n${publishAt}`)
+    .digest('hex');
+
+  // Evita duplicados por chave (não publicado)
+  const exists = queue.some(j => !j.done && j.idempotencyKey === idempotencyKey);
+  if (exists) {
+    return res.status(200).json({ ok: true, queued: true, duplicate: true, idempotencyKey, traceId: req.id });
+  }
+
+  queue.push({ imageUrl, caption, publishAt, idempotencyKey, done: false, attempts: 0, lastError: null });
+  return res.status(201).json({ ok: true, queued: true, idempotencyKey, traceId: req.id });
 });
 
-/* -------------------------------------------------------------------- */
-/*  CRON – verifica a fila a cada minuto                                */
-/* -------------------------------------------------------------------- */
-
-// dispara no segundo 0 de todo minuto
-cron.schedule('0 * * * * *', async () => {
+/* ----------------------------- Executor ------------------------------ */
+async function processQueue() {
   const now = Date.now();
+  let published = 0;
+  let errors = 0;
 
   for (const job of queue) {
     if (job.done) continue;
     if (new Date(job.publishAt).getTime() > now) continue;
 
     try {
-      const creationId = await ig.createImagePost(job.imageUrl, job.caption);
-      await ig.publishPost(creationId);
+      const creation = await ig.createImagePost(job.imageUrl, job.caption);
+      const creationId = typeof creation === 'string' ? creation : creation?.creationId;
+      if (!creationId) throw new Error('createImagePost não retornou creationId');
 
+      await ig.publishPost(creationId);
       job.done = true;
-      console.log('✅  Publicado:', job.caption.slice(0, 30));
+      job.lastError = null;
+      published++;
+      (log.info || console.log)({ caption: job.caption.slice(0, 50) }, '✅ Publicado');
     } catch (e) {
-      console.error('❌ Erro ao publicar:', e.response?.data || e.message);
+      job.attempts += 1;
+      job.lastError = e?.response?.data || e?.message || String(e);
+      errors++;
+      (log.error || console.error)({ err: job.lastError, attempts: job.attempts }, '❌ Erro ao publicar');
+      // (opcional) requeue/backoff simples aqui
     }
   }
+
+  return { published, errors, pending: queue.filter(j => !j.done).length };
+}
+
+/**
+ * POST /schedule/run
+ * - Para ser chamado pelo Cloud Scheduler a cada minuto.
+ * - Autenticação simples via header "X-CRON-KEY" = process.env.CRON_KEY (opcional).
+ */
+router.post('/run', async (req, res) => {
+  const expectedKey = process.env.CRON_KEY;
+  if (expectedKey) {
+    const got = req.get('x-cron-key');
+    if (got !== expectedKey) return res.status(401).json({ ok: false, error: 'unauthorized', traceId: req.id });
+  }
+
+  if (running) {
+    return res.status(202).json({ ok: true, running: true, traceId: req.id });
+  }
+
+  running = true;
+  try {
+    const result = await processQueue();
+    return res.json({ ok: true, running: false, traceId: req.id, ...result });
+  } finally {
+    running = false;
+  }
 });
+
+/* ----------------------------- Cron local ---------------------------- */
+if (process.env.USE_LOCAL_CRON === 'true') {
+  cron.schedule('0 * * * * *', async () => {
+    try {
+      await processQueue();
+    } catch (e) {
+      (log.error || console.error)({ err: e?.message || e }, 'cron/processQueue error');
+    }
+  });
+}
 
 module.exports = router;

--- a/src/services/scheduler.js
+++ b/src/services/scheduler.js
@@ -1,40 +1,139 @@
-// src/services/scheduler.js
-const cron = require('node-cron');
-const { createImagePost, publishPost } = require('./instagram');
+// src/routes/schedule.js
+'use strict';
 
-// Mantém os jobs ativos em memória
-const jobs = new Map();
+const express = require('express');
+const cron    = require('node-cron');
+const crypto  = require('crypto');
+const ig      = require('../services/instagram');
+
+const baseLog = require('../utils/log');
+const log     = (typeof baseLog.child === 'function') ? baseLog.child({ module: 'schedule' }) : baseLog;
+
+const router = express.Router();
+
+// Fila simples em memória (MVP). Em produção: persistir (Firestore/Postgres).
+const queue = [];
+let running = false;
+
+/* ------------------------------- Health ------------------------------- */
+router.get('/ping', (_req, res) => {
+  res.json({ status: 'schedule ok' });
+});
+
+/* ----------------------------- Enfileirar ----------------------------- */
+/**
+ * POST /schedule
+ * Body:
+ * {
+ *   "imageUrl": "...jpg",            // aceita também "image_url"
+ *   "caption" : "Test ✍️",
+ *   "publishAt": "2025-07-24T23:06:00Z"   // ISO-8601 (aceita "publish_at")
+ * }
+ */
+router.post('/', (req, res) => {
+  const imageUrl  = req.body.imageUrl ?? req.body.image_url;
+  const caption   = req.body.caption;
+  const publishAt = req.body.publishAt ?? req.body.publish_at;
+
+  if (!imageUrl || !caption || !publishAt) {
+    return res.status(400).json({
+      ok   : false,
+      error: 'Campos obrigatórios: imageUrl (ou image_url), caption, publishAt (ou publish_at) em ISO',
+      traceId: req.id
+    });
+  }
+
+  const ts = Date.parse(publishAt);
+  if (Number.isNaN(ts)) {
+    return res.status(400).json({ ok: false, error: 'publishAt inválido (use ISO-8601, ex.: 2025-07-24T23:06:00Z)', traceId: req.id });
+  }
+
+  // Chave idempotente simples: mesmo trio → mesma chave
+  const idempotencyKey = crypto
+    .createHash('sha256')
+    .update(`${imageUrl}\n${caption}\n${publishAt}`)
+    .digest('hex');
+
+  // Evita duplicar enquanto ainda não publicou
+  const exists = queue.some(j => !j.done && j.idempotencyKey === idempotencyKey);
+  if (exists) {
+    return res.status(200).json({ ok: true, queued: true, duplicate: true, idempotencyKey, traceId: req.id });
+  }
+
+  queue.push({ imageUrl, caption, publishAt, idempotencyKey, done: false, attempts: 0, lastError: null });
+  return res.status(201).json({ ok: true, queued: true, idempotencyKey, traceId: req.id });
+});
+
+/* ----------------------------- Executor ------------------------------ */
+async function processQueue() {
+  const now = Date.now();
+  let published = 0;
+  let errors = 0;
+
+  for (const job of queue) {
+    if (job.done) continue;
+    if (new Date(job.publishAt).getTime() > now) continue;
+
+    try {
+      const creation = await ig.createImagePost(job.imageUrl, job.caption);
+      const creationId = typeof creation === 'string' ? creation : creation?.creationId || creation?.id;
+      if (!creationId) throw new Error('createImagePost não retornou creationId');
+
+      await ig.publishPost(creationId);
+      job.done = true;
+      job.lastError = null;
+      published++;
+      (log.info || console.log)({ caption: job.caption.slice(0, 50) }, '✅ Publicado');
+    } catch (e) {
+      job.attempts += 1;
+      job.lastError = e?.response?.data || e?.message || String(e);
+      errors++;
+      (log.error || console.error)({ err: job.lastError, attempts: job.attempts }, '❌ Erro ao publicar');
+      // (opcional) implementar backoff/requeue aqui
+    }
+  }
+
+  return { published, errors, pending: queue.filter(j => !j.done).length };
+}
 
 /**
- * Agenda um post.
- * @param {string}  caption     – legenda da foto
- * @param {string}  image_url   – URL pública (jpeg/png)
- * @param {string}  datetime    – ISO-8601 UTC (ex.: 2025-07-24T22:20:00Z)
- * @returns {string} jobId      – id interno do cron
+ * POST /schedule/run
+ * - Chamado pelo Cloud Scheduler (1/min) ou manualmente.
+ * - Header obrigatório (se definido no serviço): X-CRON-KEY: <seu segredo>
  */
-function schedulePost({ caption, image_url, datetime }) {
-  const runAt  = new Date(datetime);        // ISO 8601 → objeto Date
-  const cronExpr = `${runAt.getUTCMinutes()} ${runAt.getUTCHours()} `
-                 + `${runAt.getUTCDate()} ${runAt.getUTCMonth() + 1} *`;
+router.post('/run', async (req, res) => {
+  const expectedKey = process.env.CRON_KEY;
+  if (expectedKey) {
+    const got = req.get('x-cron-key');
+    if (got !== expectedKey) {
+      return res.status(401).json({ ok: false, error: 'unauthorized', traceId: req.id });
+    }
+  }
 
-  // 1º passo: criar o container de mídia
-  return createImagePost(image_url, caption).then(({ creationId }) => {
-    const jobId = `job-${Date.now()}`;       // id único p/ mapa
+  if (running) {
+    return res.status(202).json({ ok: true, running: true, traceId: req.id });
+  }
 
-    // 2º passo: agenda a publicação
-    const task = cron.schedule(
-      cronExpr,
-      async () => {
-        await publishPost(creationId);       // publica no feed
-        task.stop();                         // executa uma vez só
-        jobs.delete(jobId);                  // remove do mapa
-      },
-      { timezone: 'UTC' }
-    );
+  running = true;
+  try {
+    const result = await processQueue();
+    return res.json({ ok: true, running: false, traceId: req.id, ...result });
+  } finally {
+    running = false;
+  }
+});
 
-    jobs.set(jobId, task);
-    return jobId;                            // devolve ao caller
+/* ----------------------------- Cron local ---------------------------- */
+/* Em dev, se quiser rodar o executor no seu PC a cada minuto:
+   defina USE_LOCAL_CRON=true no .env local. */
+if (process.env.USE_LOCAL_CRON === 'true') {
+  cron.schedule('0 * * * * *', async () => {
+    try {
+      await processQueue();
+    } catch (e) {
+      (log.error || console.error)({ err: e?.message || e }, 'cron/processQueue error');
+    }
   });
 }
 
-module.exports = { schedulePost };
+module.exports = router;

--- a/src/utils/log.backup.js
+++ b/src/utils/log.backup.js
@@ -1,0 +1,13 @@
+const LEVELS = ['error', 'warn', 'info', 'debug'];
+const current = (process.env.LOG_LEVEL || 'info').toLowerCase();
+const allow = lvl => LEVELS.indexOf(lvl) <= LEVELS.indexOf(current);
+const fmt = (lvl, args) => {
+  const time = new Date().toISOString();
+  return [`[${time}] [${lvl}]`, ...args];
+};
+module.exports = {
+  error: (...a) => allow('error') && console.error(...fmt('error', a)),
+  warn:  (...a) => allow('warn')  && console.warn (...fmt('warn',  a)),
+  info:  (...a) => allow('info')  && console.log  (...fmt('info',  a)),
+  debug: (...a) => allow('debug') && console.debug(...fmt('debug', a)),
+};

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,13 +1,99 @@
-const LEVELS = ['error', 'warn', 'info', 'debug'];
-const current = (process.env.LOG_LEVEL || 'info').toLowerCase();
-const allow = lvl => LEVELS.indexOf(lvl) <= LEVELS.indexOf(current);
-const fmt = (lvl, args) => {
+// src/utils/log.js
+'use strict';
+
+const os   = require('os');
+const util = require('util');
+
+const LEVELS = Object.freeze(['error', 'warn', 'info', 'debug']);
+
+const envLevel = String(process.env.LOG_LEVEL || 'info').toLowerCase();
+const currentIdx = LEVELS.includes(envLevel) ? LEVELS.indexOf(envLevel) : LEVELS.indexOf('info');
+const allow = (lvl) => LEVELS.indexOf(lvl) <= currentIdx;
+
+const asJson       = /^true$/i.test(process.env.LOG_JSON || '');           // LOG_JSON=true → JSON estruturado (Cloud Logging-friendly)
+const warnToStderr = /^true$/i.test(process.env.LOG_WARN_TO_STDERR || ''); // opcional: warn no stderr
+const serviceName  = process.env.LOG_NAME || 'jarvis-bot';
+
+const baseMeta = Object.freeze({
+  service: serviceName,
+  env: process.env.NODE_ENV || 'production',
+  pid: process.pid,
+  host: os.hostname(),
+});
+
+const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Error);
+
+// redator de segredos (token/secret/password/authorization/appsecret_proof)
+function redact(value) {
+  const seen = new WeakSet();
+  const re = /(token|secret|password|authorization|appsecret_proof)/i;
+  return JSON.stringify(value, (k, v) => {
+    if (re.test(k)) return '[redacted]';
+    if (typeof v === 'object' && v !== null) {
+      if (seen.has(v)) return '[circular]';
+      seen.add(v);
+    }
+    return v;
+  });
+}
+
+function write(lvl, args, fixedMeta = {}) {
+  if (!allow(lvl)) return;
+
   const time = new Date().toISOString();
-  return [`[${time}] [${lvl}]`, ...args];
-};
-module.exports = {
-  error: (...a) => allow('error') && console.error(...fmt('error', a)),
-  warn:  (...a) => allow('warn')  && console.warn (...fmt('warn',  a)),
-  info:  (...a) => allow('info')  && console.log  (...fmt('info',  a)),
-  debug: (...a) => allow('debug') && console.debug(...fmt('debug', a)),
-};
+  const arr  = Array.isArray(args) ? args.slice() : [];
+
+  // pega meta como último argumento se for objeto simples
+  let meta;
+  if (arr.length && isPlainObject(arr[arr.length - 1])) {
+    meta = arr.pop();
+  }
+
+  // captura primeiro Error (em qualquer posição)
+  const err = arr.find((a) => a instanceof Error);
+
+  // formatação estilo console (%s, %d etc.)
+  const message = arr.length ? util.format(...arr) : '';
+
+  if (asJson) {
+    // formato ideal p/ Cloud Logging
+    const entry = {
+      severity: lvl.toUpperCase(),
+      time,
+      message,
+      ...baseMeta,
+      ...fixedMeta,
+    };
+    if (err)  entry.error = { name: err.name, message: err.message, stack: err.stack };
+    if (meta) entry.meta  = meta;
+
+    const sink = (lvl === 'error' || (lvl === 'warn' && warnToStderr)) ? console.error : console.log;
+    sink(redact(entry));
+    return;
+  }
+
+  // texto simples
+  const prefix = `[${time}] [${lvl}]`;
+  const sink   = (lvl === 'error' || (lvl === 'warn' && warnToStderr)) ? console.error : console.log;
+
+  if (message) sink(prefix, message);
+  if (meta)    sink(prefix, redact({ ...fixedMeta, meta }));
+  if (err && !message) sink(prefix, err.stack || err.message);
+}
+
+// logger “filho” com meta fixa (ex.: módulo/rota)
+function child(extraMeta = {}) {
+  const fixed = isPlainObject(extraMeta) ? extraMeta : {};
+  return {
+    error: (...a) => write('error', a, fixed),
+    warn:  (...a) => write('warn',  a, fixed),
+    info:  (...a) => write('info',  a, fixed),
+    debug: (...a) => write('debug', a, fixed),
+    child: (m) => child({ ...fixed, ...(m || {}) }),
+  };
+}
+
+// instância padrão (compat com require('../utils/log'))
+const log = child();
+module.exports = log;
+module.exports.default = log; // compat ESM


### PR DESCRIPTION
- Novo endpoint POST /schedule/run com header X-CRON-KEY
- Fila em memória com idempotência (sha256 de imageUrl+caption+publishAt)
- Executor processa itens vencidos e publica no IG
- Health: GET /schedule/ping
- services/scheduler.js marcado como LEGADO (mantido por compat)